### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "mkdirp": "^0.5.1",
     "morgan": "^1.7.0",
     "mysql": "^2.12.0",
-    "node-uuid": "^1.4.7",
     "pg": "^6.1.0",
     "pg-hstore": "^2.3.2",
     "pretty-error": "^2.0.2",
@@ -36,6 +35,7 @@
     "simple-git": "^1.61.0",
     "sqlite3": "3.1.8",
     "tedious": "^1.14.0",
+    "uuid": "^3.0.0",
     "whereis": "^0.4.0"
   },
   "devDependencies": {

--- a/src/lib/entities/entity.ts
+++ b/src/lib/entities/entity.ts
@@ -5,7 +5,7 @@ import * as path from 'path'
 
 import App from '../app'
 
-const uuid = require('node-uuid')
+const uuid = require('uuid')
 
 const Field = require('./field')
 const QueryGenerator = require('./query-generator')


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.